### PR TITLE
Update to newer ts3plugin and use brotli

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,19 +5,14 @@ authors = ["Splamy <splamyn@gmail.com>"]
 
 [lib]
 name = "tspressor"
-crate-type = ["dylib"]
+crate-type = ["cdylib"]
 
 [profile.release]
 lto = true
 
 [dependencies]
 lazy_static = "*"
-#xz2 = "0.1"
-rustc-serialize = "0.3"
-#clipboard = "0.1.1"
-bzip2 = "0.3.0"
-
-[dependencies.ts3plugin]
-git = "https://github.com/Flakebi/rust-ts3plugin"
-[dependencies.clipboard]
-git = "https://github.com/aweinstock314/rust-clipboard"
+base64 = "0.2"
+clipboard = "0.1"
+brotli2 = "0.2"
+ts3plugin = "0.1"


### PR DESCRIPTION
- Update to a newer version of the ts3plugin library
- Use the brotli library to compress messages
  which achieves a better compression ratio than bzip2
- Use the base64 crate instead of rust-serialize because
  it is much smaller
